### PR TITLE
Übersetzung angepasst und Fehler bei Priorität und Answer behoben (Blockly)

### DIFF
--- a/admin/blockly.js
+++ b/admin/blockly.js
@@ -39,6 +39,7 @@ Blockly.Words['pushsafer_vibration_1']   = {'en': '1',                          
 Blockly.Words['pushsafer_vibration_2']   = {'en': '2',                           'de': '2',                                  'ru': '2'};
 Blockly.Words['pushsafer_vibration_3']   = {'en': '3',                           'de': '3',                                  'ru': '3'};
 
+Blockly.Words['pushsafer_priority']     = {'en': 'Priority',                     'de': 'Priorität',                          'ru': 'Приоритет'};
 Blockly.Words['pushsafer_priority_']    = {'en': 'default',                      'de': 'normal',                             'ru': 'по умолчанию'};
 Blockly.Words['pushsafer_priority_1']   = {'en': '1',                            'de': '1',                                  'ru': '1'};
 Blockly.Words['pushsafer_priority_2']   = {'en': '2',                            'de': '2',                                  'ru': '2'};
@@ -46,6 +47,7 @@ Blockly.Words['pushsafer_priority_0']   = {'en': '0',                           
 Blockly.Words['pushsafer_priority_-1']  = {'en': '-1',                           'de': '-1',                                 'ru': '-1'};
 Blockly.Words['pushsafer_priority_-2']  = {'en': '-2',                           'de': '-2',                                 'ru': '-2'};
 
+Blockly.Words['pushsafer_answer']       = {'en': 'Answer',                       'de': 'Antwort',                            'ru': 'Ответить'};
 Blockly.Words['pushsafer_answer_']      = {'en': 'default',                      'de': 'normal',                             'ru': 'по умолчанию'};
 Blockly.Words['pushsafer_answer_0']     = {'en': '0',                            'de': '0',                                  'ru': '0'};
 Blockly.Words['pushsafer_answer_1']     = {'en': '1',                            'de': '1',                                  'ru': '1'};

--- a/admin/blockly.js
+++ b/admin/blockly.js
@@ -255,11 +255,12 @@ Blockly.Blocks['pushsafer'] = {
             .appendField(Blockly.Translate('pushsafer_priority'))
             .appendField(new Blockly.FieldDropdown([
                 [Blockly.Translate('pushsafer_priority_'),   ''],
+                [Blockly.Translate('pushsafer_priority_-2'), '-2'],
+                [Blockly.Translate('pushsafer_priority_-1'), '-1'],
                 [Blockly.Translate('pushsafer_priority_0'), '0'],
                 [Blockly.Translate('pushsafer_priority_1'), '1'],
-                [Blockly.Translate('pushsafer_priority_2'), '2'],
-                [Blockly.Translate('pushsafer_priority_-1'), '-1'],
-                [Blockly.Translate('pushsafer_priority_-2'), '-2']
+                [Blockly.Translate('pushsafer_priority_2'), '2']
+
             ]), 'PRIORITY');
         
         this.appendDummyInput('ANSWER')

--- a/admin/blockly.js
+++ b/admin/blockly.js
@@ -354,7 +354,7 @@ Blockly.JavaScript['pushsafer'] = function(block) {
     value = Blockly.JavaScript.valueToCode(block, 'DEVICE', Blockly.JavaScript.ORDER_ATOMIC);
     if (value)     text += '   device: ' + value + ',\n';
     
-    value = Blockly.JavaScript.valueToCode(block, 'PRIORITY', Blockly.JavaScript.ORDER_ATOMIC);
+    value = block.getFieldValue('PRIORITY');
     if (value)     text += '   priority: ' + value + ',\n';
     
     value = Blockly.JavaScript.valueToCode(block, 'RETRY', Blockly.JavaScript.ORDER_ATOMIC);
@@ -363,7 +363,7 @@ Blockly.JavaScript['pushsafer'] = function(block) {
     value = Blockly.JavaScript.valueToCode(block, 'EXPIRE', Blockly.JavaScript.ORDER_ATOMIC);
     if (value)     text += '   expire: ' + value + ',\n';
     
-    value = Blockly.JavaScript.valueToCode(block, 'ANSWER', Blockly.JavaScript.ORDER_ATOMIC);
+    value = block.getFieldValue('ANSWER');
     if (value)     text += '   answer: ' + value + ',\n';
 
     value = Blockly.JavaScript.valueToCode(block, 'PICTURE', Blockly.JavaScript.ORDER_ATOMIC);


### PR DESCRIPTION
In der aktuellen Version der Adapters mit dem aktuellen JavaScript Adapter funktioniert im Rahmen von Blockly-Scripten nicht mehr das Angeben einer Priorität sowie der Antwortmöglichkeit. Durch die Verwendung von block.getFieldValue(...) konnte ich die beiden Eigenschaften wieder im JavaScript zum rendern bringen.

Gleichzeitig habe ich ein paar fehlende Übersetzungen eingefügt und die Reihenfolge der Prioritäten angepasst.